### PR TITLE
Fix: filter categories default open

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -165,7 +165,7 @@ export default {
       return filters
     },
     initToggles () {
-      const arr = Array(Taxonomy.categories.length).fill(false)
+      const arr = Array(Taxonomy.categories.length).fill(true)
       return arr
     },
     selectedLabels () {


### PR DESCRIPTION
Filter categories on filter panel are open by default