### PR TITLE
Fix: all project routes now generate correctly

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -16,7 +16,7 @@ export default {
           try {
             const slug = Projects[i]
             const route = `/project/${slug}`
-            const payload = require(`./content/projects/${slug}`)
+            const payload = require(`./content/projects/${slug}.json`)
             routes.push({ route, payload })
           } catch (e) {
             if (e.code === 'MODULE_NOT_FOUND') {

--- a/pages/project/_id.vue
+++ b/pages/project/_id.vue
@@ -90,7 +90,7 @@
               <dt :key="`key-${i}`" class="name">
                 {{ info.label }}
               </dt>
-              
+
               <dd :key="`val-${i}`" class="text">
                 {{ info.value }}
               </dd>
@@ -98,10 +98,12 @@
           </dl>
         </section>
 
-        <section v-if="project.video" id="section-video">
+        <section
+          v-if="project.video && getEmbedUrl(project.video).id"
+          id="section-video">
           <div class="video-wrapper">
             <iframe
-              :src="$buildVideoEmbedUrl($parseVideoUrl(project.video))"
+              :src="getEmbedUrl(project.video)"
               class="video"
               allow="autoplay; encrypted-media"
               allowfullscreen>
@@ -278,6 +280,9 @@ export default {
   methods: {
     filterTags (categorySlug, tags = []) {
       return tags.filter(tag => this.$checkTaxonomyTagExists(categorySlug, tag))
+    },
+    getEmbedUrl (url) {
+      return this.$buildVideoEmbedUrl(this.$parseVideoUrl(url))
     }
   }
 }
@@ -400,7 +405,7 @@ export default {
         margin-top: 30px;
       }
     }
-    
+
   }
 }
 

--- a/plugins/global-methods.js
+++ b/plugins/global-methods.js
@@ -136,12 +136,15 @@ export default ({ store, app }, inject) => {
   // /////////////////////////////////////////////////////////// Parse Video URL
   // ---------------------------------- https://gist.github.com/yangshun/9892961
   inject('parseVideoUrl', (url) => {
-    url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(&\S+)?/)
-    const parsed = new URL(url)
+    const matched = url.match(/(https?:\/\/|\/\/|)(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com)|dailymotion.com)\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(&\S+)?/)
+    if (!matched) { return { type: false, id: false, time: false } }
+    const parsed = new URL(`https://placeholder-for-parsing.com/${url.split('/').pop()}`)
+    const domain = matched[3]
     let type = ''
-    if (RegExp.$3.includes('youtu')) { type = 'youtube' }
-    if (RegExp.$3.includes('vimeo')) { type = 'vimeo' }
-    return { type, id: RegExp.$6, time: parsed.searchParams.get('t') }
+    if (domain.includes('youtu')) { type = 'youtube' }
+    if (domain.includes('vimeo')) { type = 'vimeo' }
+    if (domain.includes('dailymotion')) { type = 'dailymotion' }
+    return { type, id: matched[6], time: parsed.searchParams.get('t') }
   })
   // ///////////////////////////////////////////////////// Generate an embed URL
   // ---------------------------------------------------------- Youtube or Vimeo


### PR DESCRIPTION
Well this was interesting! Some routes were failing to generate because their video urls were relative (without an explicit protocol). Apparently `new Url(url)` does not work with `//` urls without a protocol and errors out completely (thus preventing the page from being generated at all).

As well, doing the following:

```js
const url = 'https://www.youtube.com/watch?v=yhCuCqJbOVE'
url.match(/<regex>/)
console.log(RegExp.$6)
```

only works client-side 🤔 

—

`parseVideoUrl()` function now handles
- a lack of a protocol in a more foolproof way
- a non-url string

—

Support for Dailymotion videos added as well