### PR TITLE
Feat: Breadcrumbs component now correctly handles query params

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -129,7 +129,7 @@ const appendFilters2URL = (instance) => {
   if (slug) {
     instance.$router.replace({ query: { filters: 'enabled', tag: slug } })
   } else {
-    instance.$router.replace({ query: { filters: 'enabled'} })
+    instance.$router.replace({ query: { filters: 'enabled' } })
   }
 }
 

--- a/modules/zero/core/Components/Breadcrumbs.vue
+++ b/modules/zero/core/Components/Breadcrumbs.vue
@@ -5,8 +5,8 @@
       :is="link.type"
       v-for="(link, index) in breadcrumbs"
       :key="index"
-      :to="link.disabled ? '' : link.href"
-      :href="link.disabled ? '' : link.href"
+      :to="link.disabled ? '' : { path: link.href, query: link.query || false }"
+      :href="link.disabled ? '' : link.href + $CompileQueryString(link.query)"
       :disabled="link.disabled"
       :target="link.target"
       :class="link.type === 'div' ? 'breadcrumb-button' : 'breadcrumb-link'">

--- a/modules/zero/core/Plugins/helpers.js
+++ b/modules/zero/core/Plugins/helpers.js
@@ -31,9 +31,31 @@ const GetCookie = (string, key) => {
   return cookies.hasOwnProperty(key) ? cookies[key] : false
 }
 
+// ////////////////////////////////////////////////////////// CompileQueryString
+const CompileQueryString = (query) => {
+  let compiled = ''
+  if (!query || typeof query !== 'object') { return '' }
+  let len = Object.keys(query).length
+  for (const param in query) {
+    const value = query[param]
+    if (typeof value === 'string') {
+      compiled += `${param}=${value}&`
+    }
+  }
+  if (compiled !== '') {
+    compiled = `?${compiled}`
+  }
+  len = compiled.length
+  if (compiled.charAt(len - 1) === '&') {
+    compiled = compiled.slice(0, len - 1)
+  }
+  return compiled
+}
+
 // ////////////////////////////////////////////////////////////////////// Export
 // -----------------------------------------------------------------------------
 export default ({}, inject) => {
   inject('OmitDeep', OmitDeep)
   inject('GetCookie', GetCookie)
+  inject('CompileQueryString', CompileQueryString)
 }

--- a/pages/project/_id.vue
+++ b/pages/project/_id.vue
@@ -251,13 +251,14 @@ export default {
           label: 'Home'
         },
         {
-          type: 'a',
+          type: 'nuxt-link',
           href: '/',
           label: 'IPFS Ecosystem'
         },
         {
-          type: 'a',
-          href: '/projects',
+          type: 'nuxt-link',
+          href: '/',
+          query: { filters: 'enabled', foo: 'bar' },
           label: 'All projects'
         },
         {


### PR DESCRIPTION
Query params in breadcrumbs were required to navigate from the `/project/:slug` page to the `/?filters=enabled` index page state