### PR TITLE
Refactor: fetching of singular and multiple project JSON files

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -65,8 +65,6 @@ import SegmentSliderChart from '@/components/SegmentSliderChart/SegmentSliderCha
 import FeaturedProjectsSlider from '@/components/FeaturedProjectsSlider/FeaturedProjectsSlider'
 import ProjectView from '@/components/ProjectView/ProjectView'
 
-import Projects from '@/content/projects/manifest.json'
-
 // =================================================================== Functions
 const resetSectionHeight = (instance) => {
   if (!instance.filtersActive) {
@@ -98,20 +96,9 @@ export default {
   },
 
   async fetch ({ store, req }) {
-    const compiled = []
-    const len = Projects.length
-    for (let i = 0; i < len; i++) {
-      const id = Projects[i]
-      try {
-        const project = require(`@/content/projects/${id}.json`)
-        compiled.push(project)
-      } catch (e) {
-        console.log(e)
-      }
-    }
     await store.dispatch('global/getBaseData', 'general')
     await store.dispatch('global/getBaseData', 'index')
-    await store.dispatch('projects/getAllProjects', compiled)
+    await store.dispatch('projects/getProjects')
   },
 
   head () {

--- a/store/projects.js
+++ b/store/projects.js
@@ -1,3 +1,5 @@
+import Projects from '@/content/projects/manifest.json'
+
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
 const state = () => ({
@@ -17,15 +19,27 @@ const actions = {
   clearStore ({ commit }) {
     commit('CLEAR_STORE')
   },
-  // //////////////////////////////////////////////////////////// getAllProjects
-  async getAllProjects ({ commit }, payload) {
-    if (payload) {
-      await this.dispatch('projects/setProjects', payload)
+  // /////////////////////////////////////////////////////////////// getProjects
+  getProjects ({ commit }) {
+    try {
+      const compiled = []
+      const len = Projects.length
+      for (let i = 0; i < len; i++) {
+        const id = Projects[i]
+        try {
+          const project = require(`@/content/projects/${id}.json`)
+          compiled.push(project)
+        } catch (e) {
+          console.log(e)
+          continue
+        }
+      }
+      if (compiled.length > 0) {
+        commit('SET_PROJECTS', compiled)
+      }
+    } catch (e) {
+      // Silent fail
     }
-  },
-  // /////////////////////////////////////////////////////////////// setProjects
-  setProjects ({ commit }, payload) {
-    commit('SET_PROJECTS', payload)
   }
 }
 


### PR DESCRIPTION
- Since project singular routes pre-generate all payloads, it was redundant to require them again
- DRY'd up the compilation of the global `projects` array — this now occurs once in the `getProjects` Vuex action across routes