### PR TITLE
Fix: Navigate to index page bug fix

### DIFF
--- a/components/SegmentSliderChart/Chart.vue
+++ b/components/SegmentSliderChart/Chart.vue
@@ -110,8 +110,10 @@ export default {
       return 'block-segment' + ' ' + x
     },
     forceLabelsOut (next) {
-      for (let ind = 0; ind < this.segments.length; ind++) {
-        this.segments[ind].pos = this.segments[ind].offset + this.segments[ind].force * (20000 / this.$refs.chartFlex.clientWidth)
+      if (this.$refs.chartFlex) {
+        for (let ind = 0; ind < this.segments.length; ind++) {
+          this.segments[ind].pos = this.segments[ind].offset + this.segments[ind].force * (20000 / this.$refs.chartFlex.clientWidth)
+        }
       }
       return next()
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
         <section v-if="!filtersActive" key="segment">
           <div ref="segmentSlider">
             <SegmentSliderChart
-              v-if="!(this.$route.query.filters === 'enabled')"
+              v-if="!filtersActive"
               class="grid-center"
               @init="segment" />
           </div>
@@ -31,7 +31,7 @@
           </div>
         </section>
 
-        <section v-if="!(this.$route.query.filters === 'enabled') && pageData" id="section-filter" key="heading">
+        <section v-if="!filtersActive && pageData" id="section-filter" key="heading">
           <div ref="filterHeading" class="grid-center">
 
             <div class="col-12">
@@ -67,7 +67,7 @@ import ProjectView from '@/components/ProjectView/ProjectView'
 
 // =================================================================== Functions
 const resetSectionHeight = (instance) => {
-  if (!instance.filtersActive) {
+  if (!instance.filtersActive && instance.segmentSlider && instance.featuredSection) {
     const x = instance.$refs.segmentSlider.offsetHeight
     const y = instance.$refs.featuredSection.offsetHeight
     const z = instance.$refs.filterHeading.offsetHeight


### PR DESCRIPTION
This fixes errors thrown when navigating from project singular page to index page without having first arrived at the index view, i.e. via filtered results.