### PR TITLE
Fix: duplicate keys fixed in results per page selector

### DIFF
--- a/modules/zero/pagination/Components/ResultsPerPageSelector.vue
+++ b/modules/zero/pagination/Components/ResultsPerPageSelector.vue
@@ -103,7 +103,9 @@ export default {
       if (total <= displayOptions[0].amount) {
         return [total]
       }
-      displayOptions.push(total)
+      if (!this.displayOptions.includes(total)) {
+        displayOptions.push(total)
+      }
       return displayOptions
     }
   },


### PR DESCRIPTION
This fixes an error being thrown when duplicate keys are detected in the results per page selector component.