### PR TITLE
Fix: project card linking

### DIFF
--- a/components/FeaturedProjectsSlider/FeaturedProjectsSlider.vue
+++ b/components/FeaturedProjectsSlider/FeaturedProjectsSlider.vue
@@ -15,6 +15,7 @@
             v-for="(project, index) in featured"
             :key="index"
             :title="project.name"
+            :slug="project.slug"
             :description="project.description.short"
             :logo="project.logo.icon"
             :style="{ width: `${cardWidth}px` }"

--- a/components/ProjectView/ProjectCard.vue
+++ b/components/ProjectView/ProjectCard.vue
@@ -31,6 +31,10 @@ export default {
       type: String,
       required: true
     },
+    slug: {
+      type: String,
+      required: true
+    },
     description: {
       type: String,
       default: '',
@@ -45,12 +49,6 @@ export default {
       type: String,
       default: 'block-view',
       required: false
-    }
-  },
-
-  computed: {
-    slug () {
-      return this.$slugify(this.title)
     }
   }
 }

--- a/components/ProjectView/ProjectView.vue
+++ b/components/ProjectView/ProjectView.vue
@@ -108,6 +108,7 @@
               :key="project.name"
               :format="(listActive ? 'list-view' : 'block-view')"
               :title="project.name"
+              :slug="project.slug"
               :description="project.description.short"
               :logo="project.logo.icon" />
           </div>
@@ -328,9 +329,9 @@ export default {
 }
 
 // ///////////////////////////////////////////////////////////// Toggle Controls
-.active-button {
-  background-color: #052437;
-  color: #FFFFFF;
+button.button.type-C.active-button {
+  background-color: $tiber;
+  color: white;
 }
 
 .filter-toggle {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -17,6 +17,7 @@ export default {
             const slug = Projects[i]
             const route = `/project/${slug}`
             const payload = require(`./content/projects/${slug}.json`)
+            payload.slug = slug
             routes.push({ route, payload })
           } catch (e) {
             if (e.code === 'MODULE_NOT_FOUND') {

--- a/store/projects.js
+++ b/store/projects.js
@@ -28,6 +28,7 @@ const actions = {
         const id = Projects[i]
         try {
           const project = require(`@/content/projects/${id}.json`)
+          project.slug = id
           compiled.push(project)
         } catch (e) {
           console.log(e)


### PR DESCRIPTION
- Now linking to `/project/` instead of `project/`
- Now using the filename slug instead of generating a new slug based on project name (this circumvents the dot in the name bug)