### PR TITLE
Fix: sortNumbers property in project schema changed to object

### DIFF
--- a/content/data/project-schema.json
+++ b/content/data/project-schema.json
@@ -1,9 +1,9 @@
 {
   "display": "boolean",
   "featured": "boolean",
-  "sortNumbers": [{
+  "sortNumbers": {
     "label": "number"
-  }],
+  },
   "logo": {
     "icon": "string",
     "full": "string"


### PR DESCRIPTION
Following the recent change of `sortNumbers` property in project JSON files from array of objects to an object (#115), the project schema has been updated as well.