### PR TITLE
Refactor: url queries

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -129,18 +129,15 @@ const appendFilters2URL = (instance) => {
     const delimiter = i === len - 1 ? '' : ','
     slug = slug + instance.selected[i].slug + delimiter
   }
-  const cloned = CloneDeep(instance.$route.query)
-  if (slug) {
-    cloned.tags = slug
-  } else {
-    delete cloned.tags
-  }
-  setTimeout(() => { instance.$router.push({ query: cloned }) }, 10)
+  instance.setRouteQuery({
+    key: 'tags',
+    data: slug
+  })
 }
 
 const applyFiltersFromURL = (instance) => {
   const cloned = instance.resetCategories()
-  const qry = instance.$route.query.tag.split(',')
+  const qry = instance.$route.query.tags.split(',')
   const slugs = qry.filter(Boolean)
 
   const arr = []
@@ -192,7 +189,8 @@ export default {
 
   computed: {
     ...mapGetters({
-      activeTags: 'filters/activeTags'
+      activeTags: 'filters/activeTags',
+      routeQuery: 'global/routeQuery'
     }),
     ProjectFilters () {
       const filters = Taxonomy.categories
@@ -218,7 +216,7 @@ export default {
   },
 
   mounted () {
-    if (this.$route.query.filters === 'enabled' && this.$route.query.tag) {
+    if (this.$route.query.filters === 'enabled' && this.$route.query.tags) {
       applyFiltersFromURL(this)
     } else {
       this.setActiveTags(this.resetCategories())
@@ -228,7 +226,9 @@ export default {
 
   methods: {
     ...mapActions({
-      setActiveTags: 'filters/setActiveTags'
+      setActiveTags: 'filters/setActiveTags',
+      setRouteQuery: 'global/setRouteQuery',
+      setQueryString: 'global/setQueryString'
     }),
     toggleCat (ind) {
       this.$set(this.catsOpen, ind, !this.catsOpen[ind])

--- a/modules/zero/pagination/Components/Controls.vue
+++ b/modules/zero/pagination/Components/Controls.vue
@@ -56,8 +56,7 @@
 
 <script>
 // ===================================================================== Imports
-import { mapGetters } from 'vuex'
-import CloneDeep from 'lodash/cloneDeep'
+import { mapGetters, mapActions } from 'vuex'
 
 // ====================================================================== Export
 export default {
@@ -114,14 +113,14 @@ export default {
   },
 
   methods: {
+    ...mapActions({
+      setRouteQuery: 'global/setRouteQuery'
+    }),
     navigateToPage (page) {
-      const cloned = CloneDeep(this.$route.query)
-      if (page !== 1) {
-        cloned.page = page
-      } else {
-        delete cloned.page
-      }
-      this.$router.push({ query: cloned })
+      this.setRouteQuery({
+        key: 'page',
+        data: page
+      })
     }
   }
 }

--- a/modules/zero/pagination/Components/Paginate.vue
+++ b/modules/zero/pagination/Components/Paginate.vue
@@ -69,15 +69,14 @@ export default {
       setPageFromRoute(this)
     },
     collection () {
-      // this.calculateTotalPages()
-      // const cloned = CloneDeep(this.$route.query)
-      // if (this.page > this.totalPages) {
-      //   cloned.page = this.totalPages
-      // }
-      // if (cloned.page === 1) {
-      //   delete cloned.page
-      // }
-      // this.$router.push({ query: cloned })
+      this.calculateTotalPages()
+      const total = this.totalPages
+      if (this.page > total) {
+        this.setRouteQuery({
+          key: 'page',
+          data: total
+        })
+      }
     }
   },
 
@@ -97,7 +96,8 @@ export default {
       setTotalPages: 'pagination/setTotalPages',
       setDisplay: 'pagination/setDisplay',
       setCollection: 'pagination/setCollection',
-      clearStore: 'pagination/clearStore'
+      clearStore: 'pagination/clearStore',
+      setRouteQuery: 'global/setRouteQuery'
     }),
     calculateTotalPages () {
       const total = Math.ceil(this.collection.length / this.display)

--- a/modules/zero/pagination/Components/ResultsPerPageSelector.vue
+++ b/modules/zero/pagination/Components/ResultsPerPageSelector.vue
@@ -37,7 +37,6 @@
 <script>
 // ===================================================================== Imports
 import { mapGetters, mapActions } from 'vuex'
-import CloneDeep from 'lodash/cloneDeep'
 
 // ===================================================================== Functions
 const closeAllSelect = (e, instance) => {
@@ -134,7 +133,8 @@ export default {
   methods: {
     ...mapActions({
       setDisplay: 'pagination/setDisplay',
-      setTotalPages: 'pagination/setTotalPages'
+      setTotalPages: 'pagination/setTotalPages',
+      setRouteQuery: 'global/setRouteQuery'
     }),
     calculateTotalPages () {
       const total = Math.ceil(this.collection.length / this.display)
@@ -148,15 +148,18 @@ export default {
       if (!isNaN(selection)) {
         this.setDisplay(selection)
         this.calculateTotalPages()
-        const cloned = CloneDeep(this.$route.query)
-        if (this.page > this.totalPages) {
-          cloned.page = this.totalPages
+        const total = this.totalPages
+        const display = this.display
+        if (this.page > total) {
+          this.setRouteQuery({
+            key: 'page',
+            data: total
+          })
         }
-        if (cloned.page === 1) {
-          delete cloned.page
-        }
-        cloned.results = this.display
-        this.$router.push({ query: cloned })
+        this.setRouteQuery({
+          key: 'results',
+          data: display
+        })
         this.closed = true
       }
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -132,7 +132,9 @@ export default {
     ...mapGetters({
       siteContent: 'global/siteContent',
       projects: 'projects/projects',
-      filtersActive: 'filters/filtersActive'
+      filtersActive: 'filters/filtersActive',
+      routeQuery: 'global/routeQuery',
+      queryString: 'global/queryString'
     }),
     // SEO
     seo () {
@@ -155,6 +157,26 @@ export default {
     }
   },
 
+  watch: {
+    queryString (val) {
+      console.log(this.routeQuery)
+      if (val !== JSON.stringify(this.$route.query)) {
+        const cloned = CloneDeep(this.routeQuery)
+        Object.keys(cloned).forEach((key) => {
+          if (!cloned[key]) {
+            delete cloned[key]
+          }
+        })
+        if (cloned.hasOwnProperty('page')) {
+          if (cloned.page === 1) {
+            delete cloned.page
+          }
+        }
+        this.$router.push({ query: cloned })
+      }
+    }
+  },
+
   created () {
     this.$nuxt.$on('view-all-projects', () => {
       this.initFilters()
@@ -163,6 +185,13 @@ export default {
 
   mounted () {
     const filterEnabled = (this.$route.query.filters === 'enabled')
+    const cloned = CloneDeep(this.$route.query)
+    Object.keys(cloned).forEach((item) => {
+      this.setRouteQuery({
+        key: item,
+        data: cloned[item]
+      })
+    })
     this.setFiltersActive(filterEnabled)
 
     this.resize = () => { resetSectionHeight(this) }
@@ -178,14 +207,15 @@ export default {
 
   methods: {
     ...mapActions({
-      setFiltersActive: 'filters/setFiltersActive'
+      setFiltersActive: 'filters/setFiltersActive',
+      setRouteQuery: 'global/setRouteQuery'
     }),
     initFilters () {
-      const cloned = CloneDeep(this.$route.query)
-      cloned.filters = 'enabled'
-      this.$router.push({ path: '/', query: cloned })
       this.setFiltersActive(true)
-
+      this.setRouteQuery({
+        key: 'filters',
+        data: 'enabled'
+      })
       this.$refs.collapsibleSection.style.height = '0px'
       window.scrollTo(0, 0)
     }

--- a/store/global.js
+++ b/store/global.js
@@ -7,7 +7,9 @@ import TaxonomyData from '@/content/data/taxonomy.json'
 // /////////////////////////////////////////////////////////////////////// State
 // -----------------------------------------------------------------------------
 const state = () => ({
-  siteContent: {}
+  siteContent: {},
+  routeQuery: {},
+  queryString: ''
 })
 
 // ///////////////////////////////////////////////////////////////////// Getters
@@ -20,7 +22,9 @@ const getters = {
       return siteContent.general.navigation
     }
     return false
-  }
+  },
+  routeQuery: state => state.routeQuery,
+  queryString: state => state.queryString
 }
 
 // ///////////////////////////////////////////////////////////////////// Actions
@@ -47,6 +51,14 @@ const actions = {
   // //////////////////////////////////////////////////////////// setSiteContent
   setSiteContent ({ commit }, payload) {
     commit('SET_SITE_CONTENT', payload)
+  },
+  // ///////////////////////////////////////////////////////////// setRouteQuery
+  setRouteQuery ({ commit }, payload) {
+    commit('SET_ROUTE_QUERY', payload)
+  },
+  // //////////////////////////////////////////////////////////// setQueryString
+  setQueryString ({ commit }, queryString) {
+    commit('SET_QUERY_STRING', queryString)
   }
 }
 
@@ -57,9 +69,18 @@ const mutations = {
     state.siteContent = {}
     state.clipboard = false
     state.filterValue = ''
+    state.routeQuery = {}
+    state.queryString = ''
   },
   SET_SITE_CONTENT (state, payload) {
     state.siteContent[payload.key] = payload.data
+  },
+  SET_ROUTE_QUERY (state, payload) {
+    state.routeQuery[payload.key] = payload.data
+    state.queryString = JSON.stringify(state.routeQuery)
+  },
+  SET_QUERY_STRING (state, queryString) {
+    state.queryString = queryString
   }
 }
 


### PR DESCRIPTION
This refactor removes all of the router url query pushes from each component and replaces it with a single query push in the index page `watch` property. All components add their queries rather to a global store object called `routeQuery` which is stringified and watched by the index page for changes. Upon detecting changes, the index watch function will push the new query object to the router.