### PR TITLE
Fix: project singular page logo now better aligned

### DIFF
--- a/pages/project/_id.vue
+++ b/pages/project/_id.vue
@@ -498,6 +498,9 @@ export default {
 
 // ////////////////////////////////////////////////////// [Section] Project Info
 #section-project-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   margin-bottom: 3.75rem;
   @include medium {
     margin-bottom: 2rem;


### PR DESCRIPTION
There was a situation where some project logos looked misaligned like this:

<img width="475" alt="Screen Shot 2021-06-04 at 09 12 17" src="https://user-images.githubusercontent.com/11708190/121689696-ef137d80-ca92-11eb-9b53-ddb798cf737f.png">

--

<img width="399" alt="Screen Shot 2021-06-11 at 08 45 50" src="https://user-images.githubusercontent.com/11708190/121689709-f2a70480-ca92-11eb-9f8d-c2690afd5c66.png">

This is now fixed