### PR TITLE
Feat: wired up SEO to project singular page

### DIFF
--- a/content/pages/general.json
+++ b/content/pages/general.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "title": "IPFS Ecosystem Directory",
-    "description": "Interactive IPFS ecosystem directory and showcase"
+    "description": "Interactive IPFS ecosystem directory and showcase."
   },
   "og": {
     "site_name": "IPFS Ecosystem Directory",

--- a/pages/project/_id.vue
+++ b/pages/project/_id.vue
@@ -300,7 +300,8 @@ export default {
       tag: 'project',
       id: `project-${id}`,
       initSlider: false,
-      resize: false
+      resize: false,
+      project: false
     }
   },
 
@@ -312,8 +313,8 @@ export default {
   },
 
   head () {
-    const title = this.seo.title
-    const description = this.seo.description
+    const title = this.page_Title
+    const description = this.page_Description
     return {
       title,
       meta: [
@@ -340,6 +341,15 @@ export default {
     }),
     seo () {
       return this.$getSeo(this.tag)
+    },
+    name () {
+      return this.project.name
+    },
+    page_Title () {
+      return `${this.name} | ${this.seo.title}`
+    },
+    page_Description () {
+      return `${this.name} | ${this.description}`
     },
     pageData () {
       return this.siteContent.project.page_content


### PR DESCRIPTION
Page title and description now pulls from project `name` and `description` keys.