### PR TITLE
Fix: list view gap

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -14,7 +14,7 @@
           <AccordionSection
             :key="`taxonomy-category-${i}`"
             :active="active"
-            :selected="true"
+            :selected="filterPanelOpen"
             class="filter-category container">
             <AccordionHeader class="filter-category heading-wrapper">
               <div class="filter-category heading">
@@ -141,8 +141,9 @@ export default {
   computed: {
     ...mapGetters({
       siteContent: 'global/siteContent',
+      routeQuery: 'global/routeQuery',
       activeTags: 'filters/activeTags',
-      routeQuery: 'global/routeQuery'
+      filterPanelOpen: 'filters/filterPanelOpen'
     }),
     filterPanelContent () {
       return this.siteContent.index.page_content.section_filter.filter_panel

--- a/modules/zero/core/Components/Accordion/Section.vue
+++ b/modules/zero/core/Components/Accordion/Section.vue
@@ -40,6 +40,13 @@ export default {
   watch: {
     open () {
       this.$children[1].toggleOpen()
+    },
+    selected (val) {
+      if (val) {
+        this.$parent.setSelected(this.id)
+      } else {
+        this.$parent.$emit('toggle', this._uid)
+      }
     }
   },
 


### PR DESCRIPTION
@timelytree how do you feel about this? I added a watcher to the accordion section component and made its `selected` prop reactive. So by passing the `filterPanelOpen` state from the filters store to the accordion sections `selected` prop they will automatically close when the filter panel closes and open when it opens, which solves the height issues when the panel is closed.