### PR TITLE
Chore: Remove dependency for Vue analytics Nuxtjs Google Analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -112,7 +112,7 @@ export default {
     // Doc: https://github.com/nuxt-community/eslint-module
     '@nuxtjs/eslint-module',
     // Doc: https://github.com/nuxt-community/analytics-module
-    '@nuxtjs/google-analytics',
+    // '@nuxtjs/google-analytics', // removed dependencies for Vue Analytics due to issues
     // Doc: https://github.com/nuxt-community/moment-module#readme
     '@nuxtjs/moment'
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3824,14 +3824,6 @@
         }
       }
     },
-    "@nuxtjs/google-analytics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.4.0.tgz",
-      "integrity": "sha512-rDQTwHIjyjVrx8GywHPuWykJ3jRFGaHl5Iqji/y8tQWUc0yGEeHxOoR0yimzxnTS1Ph2/PubQYpgnVeEPEdL/A==",
-      "requires": {
-        "vue-analytics": "^5.22.1"
-      }
-    },
     "@nuxtjs/moment": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
@@ -14472,11 +14464,6 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
       "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
-    },
-    "vue-analytics": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz",
-      "integrity": "sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ=="
     },
     "vue-client-only": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@nuxtjs/axios": "^5.13.1",
     "@nuxtjs/eslint-config": "^6.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
-    "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/moment": "^1.6.1",
     "@nuxtjs/style-resources": "^1.0.0",
     "apollo-cache-inmemory": "^1.6.6",


### PR DESCRIPTION
This analytics module throws a warning when no GUID is supplied, and also it could be causing minification bugs, so disabling it