### PR TITLE
Feat: Manifestor now also generated `project-list.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ server.crt
 
 # Files
 project-manifest.json
+project-list.json
 
 # Runtime data
 pids

--- a/manifestor.js
+++ b/manifestor.js
@@ -1,16 +1,67 @@
+// ///////////////////////////////////////////////////////// Imports & Variables
+// -----------------------------------------------------------------------------
 const Fs = require('fs-extra')
 
-const path = {
+const paths = {
   projects: `${__dirname}/content/projects`,
-  manifest: `${__dirname}/content/data/project-manifest.json`
+  manifest: `${__dirname}/content/data/project-manifest.json`,
+  project_list: `${__dirname}/static/project-list.json` // ← to be used by embedable-view.js
 }
 
+// /////////////////////////////////////////////////////////////////// Functions
+// -----------------------------------------------------------------------------
+/*
+  Grab the project list and generate an array of slugs based on project filenames
+*/
+const getSlugs = async () => {
+  try {
+    const slugs = await Fs.readdirSync(paths.projects)
+      .filter(obj => obj !== '.DS_Store')
+      .map(obj => obj.split('.')[0])
+    console.log(slugs.join('\n'))
+    return slugs
+  } catch (e) {
+    console.log('============================================ [getSlugs] Error')
+    throw e
+  }
+}
+
+/*
+  - Open and parse all project JSON files
+  - Push all of them into an array with some information removed (to be used by embedable-view.js)
+  - Write to a JSON file
+*/
+const generateProjectListFile = async (slugs) => {
+  try {
+    const len = slugs.length
+    const compiled = []
+    for (let i = 0; i < len; i++) {
+      const slug = slugs[i]
+      const project = JSON.parse(await Fs.readFileSync(`${paths.projects}/${slug}.json`))
+      compiled.push({
+        slug,
+        name: project.name,
+        logo: project.logo,
+        description: project.description,
+        org: project.org
+      })
+    }
+    return compiled
+  } catch (e) {
+    console.log('============================= [generateProjectListFile] Error')
+    throw e
+  }
+}
+
+// ////////////////////////////////////////////////////////////////// Manifestor
+// -----------------------------------------------------------------------------
 const Manifestor = async () => {
   try {
     console.log('🚀️ Manifest projects started')
-    const entities = await Fs.readdirSync(path.projects).map(entity => entity.split('.')[0])
-    console.log(entities.join('\n'))
-    await Fs.writeFileSync(path.manifest, JSON.stringify(entities))
+    const slugs = await getSlugs()
+    await Fs.writeFileSync(paths.manifest, JSON.stringify(slugs))
+    const projectList = await generateProjectListFile(slugs)
+    await Fs.writeFileSync(paths.project_list, JSON.stringify(projectList))
     console.log('🏁 Manifest projects complete')
   } catch (e) {
     console.log('========================================== [Manifestor] Error')


### PR DESCRIPTION
`project-list.json` is an array of projects pulled from `@/content/projects/.` and is used by the Embedable View. This project list contains less information that the full project files since the Embedable View doesn't need _all_ the project data. Here's an example of data that is included:

```json
{
  "slug": "actyxos",
  "name": "ActyxOS",
  "logo": {
    "icon": "actyx.png",
    "full": "actyx-logo.svg"
  },
  "description": {
    "short": "Operating system for manufacturing applications",
    "long": "Operating system and developer tools for factory and workflow management."
  },
  "org": [
    "Actyx AG"
  ]
}
```

The project list is generated automatically during compile time inside of `@/manifestor.js`