### PR TITLE
Refactor chart labels

### DIFF
--- a/components/SegmentSliderChart/SegmentSliderChart.vue
+++ b/components/SegmentSliderChart/SegmentSliderChart.vue
@@ -9,7 +9,6 @@
 
       <Slider
         v-if="chartItems"
-        :selected-cat="chartItems[selected]"
         :selected-seg="selected"
         :parent-category="parentCategory"
         :container-height="containerHeight"
@@ -117,7 +116,7 @@ const createLabels = (instance, projects) => {
           size: count * 10,
           chars: l,
           logos: selection,
-          display: true,
+          display: false,
           description: getCategoryDescription(instance, label)
         })
       }

--- a/components/SegmentSliderChart/Slider.vue
+++ b/components/SegmentSliderChart/Slider.vue
@@ -16,7 +16,7 @@
         </button>
 
         <h3 class="title-between-buttons">
-          {{ selectedCat.label }}
+          {{ currentCategory.label }}
         </h3>
 
         <button
@@ -32,16 +32,16 @@
 
       <transition name="slide-fade" mode="out-in">
 
-        <div :key="selectedCat.label">
+        <div :key="currentCategory.label">
 
           <div class="title-large-screen">
             <h3>
-              {{ selectedCat.label }}
+              {{ currentCategory.label }}
             </h3>
           </div>
 
           <div class="description">
-            {{ selectedCat.description ? selectedCat.description : '' }}
+            {{ currentCategory.description ? currentCategory.description : '' }}
           </div>
 
           <div v-if="logos" class="logo-wrapper">
@@ -83,10 +83,6 @@ export default {
   },
 
   props: {
-    selectedCat: {
-      type: Object,
-      required: true
-    },
     selectedSeg: {
       type: Number,
       default: 0
@@ -98,26 +94,29 @@ export default {
     containerHeight: {
       type: Number,
       default: 440
-    },
-    items: {
-      type: Array,
-      default: () => []
     }
   },
 
   computed: {
     ...mapGetters({
       siteContent: 'global/siteContent',
-      routeQuery: 'filters/routeQuery'
+      routeQuery: 'filters/routeQuery',
+      segmentCollection: 'core/segmentCollection'
     }),
     filterToggleButtonText () {
       return this.siteContent.index.page_content.segment_slider.filter_toggle_button_text
     },
     logos () {
-      if (this.selectedCat.logos.length) {
-        return this.selectedCat.logos
+      if (this.currentCategory.hasOwnProperty('logos')) {
+        return this.currentCategory.logos
       }
       return false
+    },
+    currentCategory () {
+      if (this.selectedSeg in this.segmentCollection) {
+        return this.segmentCollection[this.selectedSeg]
+      }
+      return {}
     }
   },
 
@@ -135,7 +134,7 @@ export default {
     },
     jump2Filters () {
       this.setRouteQuery({ key: 'filters', data: 'enabled' })
-      this.setRouteQuery({ key: 'tags', data: this.selectedCat.slug })
+      this.setRouteQuery({ key: 'tags', data: this.currentCategory.slug })
       this.setFilterPanelOpen(true)
     },
     onSwipe (e) {

--- a/modules/zero/core/Store/index.js
+++ b/modules/zero/core/Store/index.js
@@ -10,6 +10,7 @@ const state = {
   messages: [],
   loaders: [],
   clipboard: false,
+  segmentCollection: [],
   filterValue: '',
   filteredCollection: [],
   sortedCollection: [],
@@ -22,6 +23,7 @@ const getters = {
   messages: state => state.messages,
   loaders: state => state.loaders,
   clipboard: state => state.clipboard,
+  segmentCollection: state => state.segmentCollection,
   filterValue: state => state.filterValue,
   filteredCollection: state => state.filteredCollection,
   sortedCollection: state => state.sortedCollection,
@@ -67,6 +69,10 @@ const actions = {
     this.$addTextToClipboard(text)
     commit('SET_CLIPBOARD', text)
   },
+  // ////////////////////////////////////////////////////// setSegmentCollection
+  setSegmentCollection ({ commit }, segmentCollection) {
+    commit('SET_SEGMENT_COLLECTION', segmentCollection)
+  },
   // ////////////////////////////////////////////////////////////// setClipboard
   setFilterValue ({ commit }, value) {
     commit('SET_FILTER_VALUE', value)
@@ -102,6 +108,9 @@ const mutations = {
   },
   SET_CLIPBOARD (state, text) {
     state.clipboard = text
+  },
+  SET_SEGMENT_COLLECTION (state, segmentCollection) {
+    state.segmentCollection = segmentCollection
   },
   SET_FILTER_VALUE (state, value) {
     state.filterValue = value


### PR DESCRIPTION
A refactor for the label placement on the segment slider chart. The main difference is that labels and segments are rendered first. Their widths and heights are measured and used to score them based on how far a label "spills over" its respective segment. Then segments are reordered to distribute the most problematic labels in such a way as to minimize potential overlap. Label positioning calculations are carried out from this point as was done in the previous version.