### PR TITLE
Feat: reset page on sort

### DIFF
--- a/modules/zero/filters/Store/index.js
+++ b/modules/zero/filters/Store/index.js
@@ -143,11 +143,13 @@ const mutations = {
     append2URL(state, router)
   },
   CLEAR_ROUTE_QUERY_TAGS (state, slug) {
+    state.routeQuery.page = 1
     state.routeQuery.tags = slug
     const router = this.$router
     append2URL(state, router)
   },
   CLEAR_ALL_TAGS (state) {
+    state.routeQuery.page = 1
     state.routeQuery.tags = ''
     const router = this.$router
     append2URL(state, router)

--- a/modules/zero/filters/Store/index.js
+++ b/modules/zero/filters/Store/index.js
@@ -137,6 +137,7 @@ const mutations = {
     append2URL(state, router)
   },
   SET_ROUTE_QUERY (state, payload) {
+    if (payload.key !== 'page') { state.routeQuery.page = 1 }
     state.routeQuery[payload.key] = payload.data
     const router = this.$router
     append2URL(state, router)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -85,60 +85,69 @@ import ProjectView from '@/components/ProjectView/ProjectView'
 const parseURLParams = (instance) => {
   const cloned = CloneDeep(instance.$route.query)
   instance.clearRouteQuery()
-  Object.keys(cloned).forEach((item) => {
-    if (item === 'filters') {
-      if (cloned[item] === 'enabled') {
-        instance.setFilterPanelOpen(true)
-        instance.setRouteQuery({
-          key: item,
-          data: cloned[item]
-        })
-        if (!cloned.hasOwnProperty('tags')) {
-          instance.clearAllTags()
-        }
-      } else {
-        instance.mountSegmentAndFeaturedSliders()
-      }
-    }
-    if (item === 'tags') {
-      const tags = cloned[item].split(',')
-      const slug = tags.filter(tag => instance.taxonomyLabels.hasOwnProperty(tag)).join(',')
+
+  if (cloned.hasOwnProperty('filters')) {
+    if (cloned.filters === 'enabled') {
+      instance.setFilterPanelOpen(true)
       instance.setRouteQuery({
-        key: item,
-        data: slug
+        key: 'filters',
+        data: cloned.filters
       })
-    }
-    if (item === 'page') {
-      const page = cloned[item]
-      if (!page.isNaN) {
-        if (page > 0) {
-          instance.setRouteQuery({
-            key: item,
-            data: parseInt(page)
-          })
-        }
+      if (!cloned.hasOwnProperty('tags')) {
+        instance.clearAllTags()
       }
+    } else {
+      instance.mountSegmentAndFeaturedSliders()
     }
-    if (item === 'results') {
-      const results = cloned[item]
-      if (!results.isNaN) {
-        if (results > 0) {
-          instance.setRouteQuery({
-            key: item,
-            data: parseInt(results)
-          })
-        }
-      }
-    }
-    if (item === 'sort-by' || item === 'display-type') {
-      instance.setRouteQuery({
-        key: item,
-        data: cloned[item]
-      })
-    }
-  })
-  if (!cloned.hasOwnProperty('filters')) {
+  } else {
     instance.mountSegmentAndFeaturedSliders()
+  }
+
+  if (cloned.hasOwnProperty('tags')) {
+    const tags = cloned.tags.split(',')
+    const slug = tags.filter(tag => instance.taxonomyLabels.hasOwnProperty(tag)).join(',')
+    instance.setRouteQuery({
+      key: 'tags',
+      data: slug
+    })
+  }
+
+  if (cloned.hasOwnProperty('results')) {
+    const results = cloned.results
+    if (!results.isNaN) {
+      if (results > 0) {
+        instance.setRouteQuery({
+          key: 'results',
+          data: parseInt(results)
+        })
+      }
+    }
+  }
+
+  if (cloned.hasOwnProperty('sort-by')) {
+    instance.setRouteQuery({
+      key: 'sort-by',
+      data: cloned['sort-by']
+    })
+  }
+
+  if (cloned.hasOwnProperty('display-type')) {
+    instance.setRouteQuery({
+      key: 'display-type',
+      data: cloned['display-type']
+    })
+  }
+
+  if (cloned.hasOwnProperty('page')) {
+    const page = cloned.page
+    if (!page.isNaN) {
+      if (page > 0) {
+        instance.setRouteQuery({
+          key: 'page',
+          data: parseInt(page)
+        })
+      }
+    }
   }
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -82,7 +82,7 @@ import FeaturedProjectsSlider from '@/components/FeaturedProjectsSlider/Featured
 import ProjectView from '@/components/ProjectView/ProjectView'
 
 // =================================================================== Functions
-const parseURLParams = (instance) => {
+const parseURLParams = (instance, next) => {
   const cloned = CloneDeep(instance.$route.query)
   instance.clearRouteQuery()
 
@@ -138,6 +138,12 @@ const parseURLParams = (instance) => {
     })
   }
 
+  instance.$nextTick(() => {
+    setRouteQueryPage(instance, cloned)
+  })
+}
+
+const setRouteQueryPage = (instance, cloned) => {
   if (cloned.hasOwnProperty('page')) {
     const page = cloned.page
     if (!page.isNaN) {


### PR DESCRIPTION
This PR addresses the requested change made [here](https://github.com/ipfs/ecosystem-directory/issues/166)

Manipulating the collection of projects in any way (aside from changing the page) will set the page back to 1.