### PR TITLE
Feat filter options

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -30,6 +30,7 @@
             <AccordionContent>
               <div class="filter-category chiclet-list">
                 <div
+                  v-if="includeFilterAllTag"
                   :class="['filter-category tag chiclet', { 'active-button': numberInCategory[heading.slug] === heading.tags.length }]"
                   @click="toggleAll(heading.slug)">
                   All
@@ -72,6 +73,8 @@ import Accordion from '@/modules/zero/core/Components/Accordion/Accordion'
 import AccordionHeader from '@/modules/zero/core/Components/Accordion/Header'
 import AccordionSection from '@/modules/zero/core/Components/Accordion/Section'
 import AccordionContent from '@/modules/zero/core/Components/Accordion/Content'
+
+import Settings from '@/content/data/settings.json'
 
 // =================================================================== Functions
 const toggleAllCategoryTags = (instance, heading) => {
@@ -123,6 +126,9 @@ export default {
       categoryLookUp: 'filters/categoryLookUp',
       filterPanelOpen: 'filters/filterPanelOpen'
     }),
+    includeFilterAllTag() {
+      return !Settings.behavior.excludeFilterAllTag
+    },
     filterPanelContent () {
       return this.siteContent.index.page_content.section_filter.filter_panel
     },

--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -126,8 +126,8 @@ export default {
       categoryLookUp: 'filters/categoryLookUp',
       filterPanelOpen: 'filters/filterPanelOpen'
     }),
-    includeFilterAllTag() {
-      if (typeof Settings.behavior.excludeFilterAllTag === "boolean") {
+    includeFilterAllTag () {
+      if (typeof Settings.behavior.excludeFilterAllTag === 'boolean') {
         return !Settings.behavior.excludeFilterAllTag
       }
       return true

--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -127,7 +127,10 @@ export default {
       filterPanelOpen: 'filters/filterPanelOpen'
     }),
     includeFilterAllTag() {
-      return !Settings.behavior.excludeFilterAllTag
+      if (typeof Settings.behavior.excludeFilterAllTag === "boolean") {
+        return !Settings.behavior.excludeFilterAllTag
+      }
+      return true
     },
     filterPanelContent () {
       return this.siteContent.index.page_content.section_filter.filter_panel

--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -8,7 +8,8 @@
         "firstTag": "",
         "lastTag": "other",
         "defaultView": "grid",
-        "externalLinksTargetBlank": true
+        "externalLinksTargetBlank": true,
+        "tagMatchType": "and"
     },
     "visibility": {
         "excludeSingulars": false,

--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -10,7 +10,7 @@
         "defaultView": "grid",
         "externalLinksTargetBlank": true,
         "tagMatchType": "or",
-        "excludeFilterAllTag": false
+        "excludeFilterAllTag": true
     },
     "visibility": {
         "excludeSingulars": false,

--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -9,7 +9,8 @@
         "lastTag": "other",
         "defaultView": "grid",
         "externalLinksTargetBlank": true,
-        "tagMatchType": "and"
+        "tagMatchType": "or",
+        "excludeFilterAllTag": false
     },
     "visibility": {
         "excludeSingulars": false,

--- a/modules/zero/filters/Components/Filters.vue
+++ b/modules/zero/filters/Components/Filters.vue
@@ -14,13 +14,10 @@ import Settings from '@/content/data/settings.json'
 
 // =================================================================== Functions
 const projectInclusion = (instance, selection, projectTags) => {
-  if (instance.match === 'or') {
-    return selection.some((val) => { return projectTags.includes(val) })
-  }
   if (instance.match === 'and') {
     return selection.every((val) => { return projectTags.includes(val) })
   }
-  return false
+  return selection.some((val) => { return projectTags.includes(val) })
 }
 
 // ====================================================================== Export

--- a/modules/zero/filters/Components/Filters.vue
+++ b/modules/zero/filters/Components/Filters.vue
@@ -10,6 +10,19 @@
 // ===================================================================== Imports
 import { mapActions } from 'vuex'
 
+import Settings from '@/content/data/settings.json'
+
+// =================================================================== Functions
+const projectInclusion = (instance, selection, projectTags) => {
+  if (instance.match === 'or') {
+    return selection.some((val) => { return projectTags.includes(val) })
+  }
+  if (instance.match === 'and') {
+    return selection.every((val) => { return projectTags.includes(val) })
+  }
+  return false
+}
+
 // ====================================================================== Export
 export default {
   name: 'Filters',
@@ -38,6 +51,9 @@ export default {
   },
 
   computed: {
+    match () {
+      return Settings.behavior.tagMatchType
+    },
     filtered () {
       let collection = []
       if (this.selected.length) {
@@ -51,9 +67,7 @@ export default {
               projTags.push(tax.tags[k])
             }
           }
-
-          const success = this.selected.every((val) => { return projTags.includes(val) })
-
+          const success = projectInclusion(this, this.selected, projTags)
           if (success) { collection.push(this.projects[i]) }
         }
       } else {


### PR DESCRIPTION
Two options for filtering have been added to the settings under behaviour in `content/data/settings.json`.

1. Project tags can be matched to the selected tags according to "and"/"or" logic specified in `"tagMatchType": "and"|"or" (default: "or")`

"and"
When this is set, the filters combine to give more specific results. A project must match filter A and filter B to be displayed.

"or"
When this is set, any projects that match any of the selected filters will be displayed.

2. The "All" tag per each filter category can be hidden with the following option: `"excludeFilterAllTag": true|false (default: false)`