### PR TITLE
Feat: granular clear all tags in category button

### DIFF
--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -279,7 +279,7 @@ export default {
   }
   &.number-active {
     font-size: 8pt;
-    margin: 0 0.25rem;
+    margin: 0 .75rem 0 0.35rem;
   }
   &.toggle {
     display: inline-block;
@@ -304,8 +304,7 @@ export default {
 }
 
 .granular-filter-clear {
-  @include fontSize_Mini;
-  font-weight: 600;
+  font-size: 7pt;
   margin: 0 0.125rem;
   &:hover {
     text-decoration: underline;

--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -22,6 +22,12 @@
                 <span class="filter-category number-active">
                   {{ numberInCategory[heading.slug] }} of {{ heading.tags.length }}
                 </span>
+                <span
+                  v-if="includeClearCategory"
+                  class="granular-filter-clear"
+                  @click.stop="clearCategory(heading.slug)">
+                  Clear
+                </span>
                 <h5 v-if="getSublabel(heading)" class="filter-category sub-heading">
                   {{ getSublabel(heading) }}
                 </h5>
@@ -132,6 +138,12 @@ export default {
       }
       return true
     },
+    includeClearCategory () {
+      if (typeof Settings.behavior.includeGranularFilterClearButton === 'boolean') {
+        return Settings.behavior.includeGranularFilterClearButton
+      }
+      return false
+    },
     filterPanelContent () {
       return this.siteContent.index.page_content.section_filter.filter_panel
     },
@@ -181,6 +193,9 @@ export default {
     },
     toggleAll (heading) {
       toggleAllCategoryTags(this, heading)
+    },
+    clearCategory (heading) {
+      this.clearRouteQueryTags(heading)
     },
     clearSelected () {
       this.clearAllTags()
@@ -264,6 +279,7 @@ export default {
   }
   &.number-active {
     font-size: 8pt;
+    margin: 0 0.25rem;
   }
   &.toggle {
     display: inline-block;
@@ -284,6 +300,15 @@ export default {
   &.chiclet-list {
     padding: 6px 0;
     margin: 0 6px;
+  }
+}
+
+.granular-filter-clear {
+  @include fontSize_Mini;
+  font-weight: 600;
+  margin: 0 0.125rem;
+  &:hover {
+    text-decoration: underline;
   }
 }
 

--- a/components/FilterPanel/FilterPanel.vue
+++ b/components/FilterPanel/FilterPanel.vue
@@ -23,7 +23,7 @@
                   {{ numberInCategory[heading.slug] }} of {{ heading.tags.length }}
                 </span>
                 <span
-                  v-if="includeClearCategory"
+                  v-if="includeClearCategory && (numberInCategory[heading.slug] > 0)"
                   class="granular-filter-clear"
                   @click.stop="clearCategory(heading.slug)">
                   Clear

--- a/content/data/settings.json
+++ b/content/data/settings.json
@@ -10,7 +10,8 @@
         "defaultView": "grid",
         "externalLinksTargetBlank": true,
         "tagMatchType": "or",
-        "excludeFilterAllTag": true
+        "excludeFilterAllTag": true,
+        "includeGranularFilterClearButton": true
     },
     "visibility": {
         "excludeSingulars": false,


### PR DESCRIPTION
This PR adds an option to display a "clear" button beside each category heading in the filter panel which clears all the tags in that specific category. The option is specified in the `content/data/settings.json` file under `behavior`:

`"includeGranularFilterClearButton": true|false (default: false)`