### PR TITLE
Chore build error sane default

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "node manifestor.js && nuxt",
     "start": "nuxt start",
     "build": "node manifestor.js && nuxt build",
-    "generate": "node manifestor.js && nuxt generate",
+    "generate": "node manifestor.js && nuxt generate --fail-on-error",
     "launch": "nuxt build && pm2 restart ipfs-ecosystem-directory",
     "reload": "pm2 restart ipfs-ecosystem-directory"
   },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Interactive IPFS ecosystem directory and showcase",
   "author": {
-    "name": "Nauras Jabari",
-    "email": "nauras@agencyundone.com"
+    "name": "Agency Undone",
+    "email": "hello@agencyundone.com"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
`nuxt`, when generating in `static` target, will now exit via `stderr` if something goes wrong with the build.

Previously errors and warnings were simply written to `stdout`, so the build would continue and checks would pass, even if the site didn't build correctly.

No modification is required to the build command for the host service (Fleek, Netlify, etc.), `npm ci && npm run generate` is the ideal command for non-local (staging and production) instances of this app.