### PR TITLE
Refactor: Clean up `nuxt-module-ipfs`

### DIFF
--- a/modules/nuxt-module-ipfs/index.js
+++ b/modules/nuxt-module-ipfs/index.js
@@ -9,7 +9,7 @@
 // ///////////////////////////////////////////////////////////////////// General
 import Path from 'path'
 import { readFileSync, readdirSync, writeFileSync } from 'fs'
-import klaw from 'klaw'
+import Klaw from 'klaw'
 
 // ///////////////////////////////////////////////////////////////////// Plugins
 const MethodsPlugin = Path.resolve(__dirname, 'plugin.js')
@@ -33,72 +33,16 @@ const registerPlugins = (instance, next) => {
   if (next) { return next() }
 }
 
-// -------------------------------------------------------------------- addHooks
-const addHooks = async (instance) => {
-  // Verify with
-  //
-  // ack ipfs/hash -c | grep -v '0$
-  instance.nuxt.hook('generate:done', async () => {
-    const { dir: generateRoot } = instance.options.generate
-    const htmlFiles = await walk(generateRoot, '.html')
-    for (const htmlFile of htmlFiles) {
-      const prefix = relative(htmlFile)
-      seds(/basePath:"\/ipfs\/hash\/"/gm, htmlFile, (
-        'basePath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
-      ))
-      seds(/assetsPath:"\/_nuxt\/"/gm, htmlFile, (
-        'assetsPath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'.\') + \'/_nuxt/\''
-      ))
-      seds(/staticAssetsBase:"(\/_nuxt\/static\/)([^"]+)/gm, htmlFile, (_, start, end) => {
-       return `staticAssetsBase:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:'.'))+"\u002F_nuxt\u002Fstatic\u002F${end}`
-      })
-      seds(/<base href="\/ipfs\/hash\/">/, htmlFile, true ? '' : (
-        '<script>\n' +
-        'base = document.createElement(\'base\')\n' +
-        'base.href = (ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]+\'/\':\'/\'))\n' +
-        'document.getElementsByTagName(\'head\')[0].appendChild(base)\n' +
-        '</script>'
-        // '<base onload="this.href=(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:\'\'))">'
-      ))
-      seds(/"\/ipfs\/hash\//gms, htmlFile, `"${prefix}`)
-      // seds(/rel="preload" href=\"_nuxt/gms, htmlFile, `rel="preload" href="${prefix}_nuxt`)
-      seds(/".\/images\//gms, htmlFile, `"${prefix}images/`)
-      seds(/url\(\/ipfs\/hash\//gms, htmlFile, `url(${prefix}`)
-    }
-
-    const nuxtRoot = Path.join(generateRoot, '_nuxt')
-    const jsFiles = await walk(nuxtRoot, '.js')
-    for (const jsFile of jsFiles) {
-      seds(/"\/ipfs\/hash\/_nuxt\/\"/, jsFile, (
-        '(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]+\'\/_nuxt\/\':\'\/_nuxt\/\')'
-      ))
-      seds(/base: '\/ipfs\/hash\/'/gm, jsFile, (
-        'base:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
-      ))
-      seds(/(staticAssetsBase:"\\u002Fipfs\\u002Fhash\\u002F_nuxt\\u002Fstatic\\u002F)([^"]+)/gm, jsFile, (_, start, end) => {
-       return `staticAssetsBase:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:''))+"/_nuxt\u002Fstatic\u002F${end}`
-      })
-      seds(/basePath:"\\u002Fipfs\\u002Fhash\\u002F"/gm, jsFile, (
-        'basePath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
-      ))
-      seds(/assetsPath:"\\u002Fipfs\\u002Fhash\\u002F_nuxt\\u002F"/gm, jsFile, (
-        'assetsPath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'.\') + \'/_nuxt/\''
-      ))
-      seds(/return __webpack_require__\.p/gm, jsFile, (
-        'return __webpack_require__.p.replace(\'./\', (ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]+\'/\':\'/\'))'
-      ))
-    }
-  })
-}
-
-function seds (re, filepath, modifier) {
+// ------------------------------------------------------------------------ seds
+const seds = (re, filepath, modifier) => {
   const original = readFileSync(filepath, 'utf8')
   const modified = original.replace(re, modifier)
   writeFileSync(filepath, modified)
   return modified
 }
 
-function relative (filepath) {
+// ------------------------------------------------------------------ relativize
+const relativize = (filepath) => {
   ([,filepath] = filepath.split('/dist/'))
   let prefix = []
   let length = filepath.split('/').length - 1
@@ -109,25 +53,92 @@ function relative (filepath) {
   return (prefix === '/' || prefix === '') ? './' : prefix
 }
 
-export function walk (dir, ext) {
-  const matches = []
-  return new Promise((resolve) => {
-    klaw(dir)
+// ------------------------------------------------------------------------ walk
+const walk = (dir, ext) => {
+  return new Promise((next) => {
+    const matches = []
+    Klaw(dir)
       .on('data', ({ path }) => {
         if (path && !path.includes('node_modules') && path.endsWith(ext)) {
           matches.push(path)
         }
       })
       .on('end', () => {
-        resolve(matches)
+        next(matches)
       })
+  })
+}
+
+// ------------------------------------------------------------ processHtmlFiles
+const processHtmlFiles = async (generateRoot) => {
+  const htmlFiles = await walk(generateRoot, '.html')
+  for (const htmlFile of htmlFiles) {
+    const prefix = relativize(htmlFile)
+    seds(/basePath:"\/ipfs\/hash\/"/gm, htmlFile, (
+      'basePath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
+    ))
+    seds(/assetsPath:"\/_nuxt\/"/gm, htmlFile, (
+      'assetsPath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'.\') + \'/_nuxt/\''
+    ))
+    seds(/staticAssetsBase:"(\/_nuxt\/static\/)([^"]+)/gm, htmlFile, (_, start, end) => {
+     return `staticAssetsBase:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:'.'))+"\u002F_nuxt\u002Fstatic\u002F${end}`
+    })
+    seds(/<base href="\/ipfs\/hash\/">/, htmlFile, true ? '' : (
+      '<script>\n' +
+      'base = document.createElement(\'base\')\n' +
+      'base.href = (ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]+\'/\':\'/\'))\n' +
+      'document.getElementsByTagName(\'head\')[0].appendChild(base)\n' +
+      '</script>'
+      // '<base onload="this.href=(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:\'\'))">'
+    ))
+    seds(/"\/ipfs\/hash\//gms, htmlFile, `"${prefix}`)
+    // seds(/rel="preload" href=\"_nuxt/gms, htmlFile, `rel="preload" href="${prefix}_nuxt`)
+    seds(/".\/images\//gms, htmlFile, `"${prefix}images/`)
+    seds(/url\(\/ipfs\/hash\//gms, htmlFile, `url(${prefix}`)
+  }
+}
+
+// -------------------------------------------------------------- processJsFiles
+const processJsFiles = async (generateRoot) => {
+  const nuxtRoot = Path.join(generateRoot, '_nuxt')
+  const jsFiles = await walk(nuxtRoot, '.js')
+  for (const jsFile of jsFiles) {
+    seds(/"\/ipfs\/hash\/_nuxt\/\"/, jsFile, (
+      '(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]+\'\/_nuxt\/\':\'\/_nuxt\/\')'
+    ))
+    seds(/base: '\/ipfs\/hash\/'/gm, jsFile, (
+      'base:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
+    ))
+    seds(/(staticAssetsBase:"\\u002Fipfs\\u002Fhash\\u002F_nuxt\\u002Fstatic\\u002F)([^"]+)/gm, jsFile, (_, start, end) => {
+     return `staticAssetsBase:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:''))+"/_nuxt\u002Fstatic\u002F${end}`
+    })
+    seds(/basePath:"\\u002Fipfs\\u002Fhash\\u002F"/gm, jsFile, (
+      'basePath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'/\')'
+    ))
+    seds(/assetsPath:"\\u002Fipfs\\u002Fhash\\u002F_nuxt\\u002F"/gm, jsFile, (
+      'assetsPath:(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]:\'.\') + \'/_nuxt/\''
+    ))
+    seds(/return __webpack_require__\.p/gm, jsFile, (
+      'return __webpack_require__.p.replace(\'./\', (ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+\\//), ipfsMatch?ipfsMatch[0]+\'/\':\'/\'))'
+    ))
+  }
+}
+
+// -------------------------------------------------------------------- addHooks
+const addHooks = async (instance) => {
+  instance.nuxt.hook('generate:done', async () => {
+    const { dir: generateRoot } = instance.options.generate
+    await processHtmlFiles(generateRoot)
+    await processJsFiles(generateRoot)
   })
 }
 
 // ////////////////////////////////////////////////////////////////// Initialize
 // -----------------------------------------------------------------------------
 function NuxtModuleIpfs () {
-  console.log(`📦 [Module] NuxtModuleIpfs`)
+  if (process.server) {
+    console.log(`📦 [Module] NuxtModuleIpfs`)
+  }
   registerPlugins(this, () => {
     if (process.env.NODE_ENV !== 'development') {
       addHooks(this)

--- a/modules/nuxt-module-ipfs/index.js
+++ b/modules/nuxt-module-ipfs/index.js
@@ -89,10 +89,8 @@ const processHtmlFiles = async (generateRoot) => {
       'base.href = (ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]+\'/\':\'/\'))\n' +
       'document.getElementsByTagName(\'head\')[0].appendChild(base)\n' +
       '</script>'
-      // '<base onload="this.href=(ipfsMatch=window.location.pathname.match(/\\/ip[fn]s\\/[^/]+/),(ipfsMatch?ipfsMatch[0]:\'\'))">'
     ))
     seds(/"\/ipfs\/hash\//gms, htmlFile, `"${prefix}`)
-    // seds(/rel="preload" href=\"_nuxt/gms, htmlFile, `rel="preload" href="${prefix}_nuxt`)
     seds(/".\/images\//gms, htmlFile, `"${prefix}images/`)
     seds(/"\/favicon\//gms, htmlFile, `"${prefix}favicon/`)
     seds(/url\(\/ipfs\/hash\//gms, htmlFile, `url(${prefix}`)

--- a/modules/nuxt-module-ipfs/index.js
+++ b/modules/nuxt-module-ipfs/index.js
@@ -94,6 +94,7 @@ const processHtmlFiles = async (generateRoot) => {
     seds(/"\/ipfs\/hash\//gms, htmlFile, `"${prefix}`)
     // seds(/rel="preload" href=\"_nuxt/gms, htmlFile, `rel="preload" href="${prefix}_nuxt`)
     seds(/".\/images\//gms, htmlFile, `"${prefix}images/`)
+    seds(/"\/favicon\//gms, htmlFile, `"${prefix}favicon/`)
     seds(/url\(\/ipfs\/hash\//gms, htmlFile, `url(${prefix}`)
   }
 }

--- a/modules/nuxt-module-ipfs/plugin.js
+++ b/modules/nuxt-module-ipfs/plugin.js
@@ -4,7 +4,9 @@
  *
  */
 
-console.log(`🔌 [Module | NuxtModuleIpfs] Methods`)
+if (process.server) {
+  console.log(`🔌 [Module | NuxtModuleIpfs] Methods`)
+}
 
 // /////////////////////////////////////////////////////////////////// Functions
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- Performing some light code cleanup, DRY-ing and commenting
- Relativized favicon for gateway URL server-side paths. Unfortunately since there's no elegant way to wrap the favicon paths in `nuxt.config.js` and `app.html` in our `$relativity` method, the favicon will not load correctly on _client-side_ navigation on _gateway URLs only_.