### PR TITLE
Show project name instead of string "project.name" in showcase

### DIFF
--- a/pages/_slug/index.vue
+++ b/pages/_slug/index.vue
@@ -17,7 +17,7 @@
           </h2>
           <div class="taxonomy-projects">
             <div v-for="(project, projectIndex) in tax.projects" :key="`project-${projectIndex}`" class="thumbnail">
-              <img :src="$relativity(`/images/projects/${project.logo}`)" :alt="project.name" title="project.name" />
+              <img :src="$relativity(`/images/projects/${project.logo}`)" :alt="project.name" :title="project.name" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
In showcase view all projects show the "project.name" tooltip when mouse over the icon. This PR solves that and shows the project name instead.