### PR TITLE
chore: update ecosystem directory nuxt module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ipfs-ecosystem-directory",
       "version": "1.0.0",
       "dependencies": {
-        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.22",
+        "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.26",
         "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
         "@nuxtjs/eslint-config": "^7.0.0",
         "@nuxtjs/eslint-module": "^3.0.2",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.22.tgz",
-      "integrity": "sha512-6geZclq3OVcXobRuWqkfPrMibJUpuThIncyKXfL1M122QGKiZmpAFMjeUcPmv3ZjMLVMbUWLyV1zlN1MZ0ELRg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.26.tgz",
+      "integrity": "sha512-GI2meHj0RPJ+aLpkSZTmFSoyfiPWLQ5X5nnFGNHWh7M3Wwhey3fouLdJzUCCZaF8IkX2sGL6vI7NPEVR28vVSw==",
       "dependencies": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",
@@ -15545,9 +15545,9 @@
       }
     },
     "@agency-undone/nuxt-module-ecosystem-directory": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.22.tgz",
-      "integrity": "sha512-6geZclq3OVcXobRuWqkfPrMibJUpuThIncyKXfL1M122QGKiZmpAFMjeUcPmv3ZjMLVMbUWLyV1zlN1MZ0ELRg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@agency-undone/nuxt-module-ecosystem-directory/-/nuxt-module-ecosystem-directory-1.0.26.tgz",
+      "integrity": "sha512-GI2meHj0RPJ+aLpkSZTmFSoyfiPWLQ5X5nnFGNHWh7M3Wwhey3fouLdJzUCCZaF8IkX2sGL6vI7NPEVR28vVSw==",
       "requires": {
         "@agency-undone/au-nuxt-module-zero": "^1.0.16",
         "countly-sdk-web": "^20.11.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=16.13.0"
   },
   "dependencies": {
-    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.22",
+    "@agency-undone/nuxt-module-ecosystem-directory": "^1.0.26",
     "@agency-undone/nuxt-module-ipfs": "^1.0.2-alpha.4",
     "@nuxtjs/eslint-config": "^7.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",


### PR DESCRIPTION
Update to the most recent version of the `nuxt-module-ecosystem-directory` package. This fixes a bug where selecting a filter in the filter panel would auto scroll to the top of the page.

Ticket: AU-2743
https://www.notion.so/agencyundone/Auto-scroll-on-IPFS-and-Eco-x-Filters-bab19c6506f54ec7bc7639ead098d4da?pvs=4